### PR TITLE
Using stack to build, fixes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Thumbs.db
 dist
 tags
 *.prof
+
+# stack #
+#########
+.stack-work

--- a/gdiff-th.cabal
+++ b/gdiff-th.cabal
@@ -1,32 +1,32 @@
 Name:                gdiff-th
-Version:             0.1.0.8
+Version:             0.1.0.9
 
 Synopsis:            Generate gdiff GADTs and Instances.
-Description:  
-    Generate gdiff GADTs and Instances. 
+Description:
+    Generate gdiff GADTs and Instances.
     .
     There are examples in the @examples@ directory of the cabal tarball. Also the main module includes an example in the documentation.
     .
-    * 0.1.0.4 : Builds on GHC 7.6.1, 7.4.2, and 7.0.3
+    * 0.1.0.4 : Builds on GHC 7.10.3, 7.6.1, 7.4.2, and 7.0.3
     .
     * 0.1.0.5 : Doc fixes.
 
 License:             BSD3
 License-file:        LICENSE
-Author:  Jonathan Fischoff            
+Author:  Jonathan Fischoff
 Maintainer:          jonathangfischoff@gmail.com
-Copyright: (c) 2012-2013 Jonathan Fischoff           
+Copyright: (c) 2012-2013 Jonathan Fischoff
 Category:            Generics, Testing
 
 Build-type:          Simple
-    
+
 Extra-source-files: examples/Expr.hs
                     examples/New.hs
                     examples/Old.hs
                     examples/CompareVersions.hs
                     examples/Parser.hs
                     examples/Utils.hs
-                    
+
 Cabal-version:       >=1.8
 
 homepage:    https://github.com/jfischoff/gdiff-th
@@ -40,38 +40,38 @@ source-repository head
 
 Library
   Hs-Source-Dirs: src
- 
+
   Exposed-modules: Data.Generic.Diff.TH
-  
-  Other-modules: Data.Generic.Diff.TH.Conversion, 
+
+  Other-modules: Data.Generic.Diff.TH.Conversion,
                  Data.Generic.Diff.TH.Internal,
                  Data.Generic.Diff.TH.Types
                  Data.Generic.Diff.TH.Specialize
-  
-  Build-depends: base >= 4.0 && <= 6.0,
-                 gdiff == 1.0.*,
-                 th-expand-syns == 0.3.*,
-                 uniplate == 1.6.*,
-                 containers,
-                 mtl == 2.2.*
-                    
+
+  Build-depends: base >= 4.0
+               , gdiff
+               , th-expand-syns
+               , uniplate 
+               , containers
+               , mtl
+
  if impl(ghc == 7.0.3)
     Build-depends: template-haskell < 2.6.0
  else
-    Build-depends: template-haskell < 2.10.0
+    Build-depends: template-haskell >= 2.10.0
     ghc-options: -Wall
-                 
+
 Test-Suite tests
     Hs-Source-Dirs: src, tests
     type:       exitcode-stdio-1.0
     main-is:    Main.hs
-    build-depends:   base >= 4.0 && <= 6.0,
-                     template-haskell < 2.10.0,
-                     gdiff == 1.0.*,
-                     th-expand-syns == 0.3.*,
-                     uniplate == 1.6.*,
-                     containers,
-                     mtl == 2.1.*
+    build-depends:   base >= 4.0
+                   , template-haskell 
+                   , gdiff 
+                   , th-expand-syns 
+                   , uniplate 
+                   , containers
+                   , mtl 
 
 --Executable CompareVersions
 --    Hs-Source-Dirs: examples, src
@@ -90,10 +90,10 @@ Test-Suite tests
 --                   deepseq == 1.3.*,
 --                   deepseq-th == 0.1.*
 --    ghc-options: -fprof-auto -threaded -rtsopts
- 
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,37 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-6.1
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- gdiff-1.1
+- text-1.2.2.1
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor


### PR DESCRIPTION
I've updated the cabal file and added a stack.yaml to compile using `stack`. You may not like the missing bounds on dependencies but it's much easier to use stack and not worry about it, letting the solver resolve it.
